### PR TITLE
Update Node.js to version 20.x

### DIFF
--- a/debian.sh
+++ b/debian.sh
@@ -136,7 +136,7 @@ fi
 #**************************************************************************************************
 
 # Node JS
-curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
 
 # Agent dependencies
 echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections

--- a/debian.sh
+++ b/debian.sh
@@ -136,7 +136,7 @@ fi
 #**************************************************************************************************
 
 # Node JS
-curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_20.x | sudo -E bash -
 
 # Agent dependencies
 echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections


### PR DESCRIPTION
Update node.js to version 20.x in order to support existing version of lighthouse https://github.com/catchpoint/WebPageTest.agent/issues/671 that currently supported only 18.x or later versions